### PR TITLE
Use Types::Standard for attribute checking

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -35,6 +35,7 @@ skip = ^(?:strict|warnings|utf8)$  ; Those are core modules.
 skip = ^Sereal(?:::(?:Decoder|Encoder))?$
 skip = ^strictures$
 skip = ^t::TestApp::RedisMock$
+skip = ^Types::Standard$           ; Part of Type::Tiny
 [Prereqs]
 strictures = 0
 [Prereqs / RuntimeRecommends]

--- a/lib/Dancer2/Plugin/Redis.pm
+++ b/lib/Dancer2/Plugin/Redis.pm
@@ -8,12 +8,12 @@ BEGIN {
 }
 
 use Carp qw( carp croak );
-use Dancer2::Core::Types qw( Undef AnyOf InstanceOf );
 use Dancer2::Plugin;  # makes this a Moo::Role!
 use Redis;
 use Safe::Isa;
 use Try::Tiny;
 use Type::Tiny;
+use Types::Standard qw( Maybe InstanceOf );
 
 =head1 SYNOPSIS
 
@@ -76,7 +76,7 @@ my $TYPE_SERIALIZATIONOBJECT = Type::Tiny->new(
 
 has _serialization => (
   is      => 'lazy',
-  isa     => AnyOf [ Undef, $TYPE_SERIALIZATIONOBJECT ],
+  isa     => Maybe[$TYPE_SERIALIZATIONOBJECT],
   builder => sub {
     my ($dsl1) = @_;
     my $conf = plugin_setting;
@@ -102,7 +102,7 @@ has _serialization => (
 
 has _redis => (
   is      => 'lazy',
-  isa     => AnyOf [ InstanceOf ['Redis'], InstanceOf ['t::TestApp::RedisMock'] ],
+  isa     => InstanceOf ['Redis', 't::TestApp::RedisMock' ],
   builder => sub {
     my ($dsl2) = @_;
     my $conf = plugin_setting;


### PR DESCRIPTION
Dancer2 0.166001_03 switched from MooX::Types::MooseLike to Type::Tiny,
which doesn't support "AnyOf". Both packages support "InstanceOf", but
handle multiple classes differently -- the former returns true if all
match, the latter returns true if any match.

So, given incompatible behaviour, and the fact that we're already
depending on Type::Tiny, I switched to Types::Standard. It's what
Dancer2::Core::Types is now using, but this way we can support older
versions of Dancer2 as well.