### PR TITLE
Dancer2 now uses Type::Tiny so update constraints accordingly

### DIFF
--- a/lib/Dancer2/Plugin/Redis.pm
+++ b/lib/Dancer2/Plugin/Redis.pm
@@ -8,7 +8,7 @@ BEGIN {
 }
 
 use Carp qw( carp croak );
-use Dancer2::Core::Types qw( Undef AnyOf InstanceOf );
+use Dancer2::Core::Types qw( Maybe Undef InstanceOf );
 use Dancer2::Plugin;  # makes this a Moo::Role!
 use Redis;
 use Safe::Isa;
@@ -76,7 +76,7 @@ my $TYPE_SERIALIZATIONOBJECT = Type::Tiny->new(
 
 has _serialization => (
   is      => 'lazy',
-  isa     => AnyOf [ Undef, $TYPE_SERIALIZATIONOBJECT ],
+  isa     => Maybe [ $TYPE_SERIALIZATIONOBJECT ],
   builder => sub {
     my ($dsl1) = @_;
     my $conf = plugin_setting;
@@ -102,7 +102,7 @@ has _serialization => (
 
 has _redis => (
   is      => 'lazy',
-  isa     => AnyOf [ InstanceOf ['Redis'], InstanceOf ['t::TestApp::RedisMock'] ],
+  isa     => InstanceOf ['Redis'] | InstanceOf ['t::TestApp::RedisMock'],
   builder => sub {
     my ($dsl2) = @_;
     my $conf = plugin_setting;


### PR DESCRIPTION
Since v0.200000 Dancer2 switched from MooX::Types::MooseLike to Type::Tiny for Dancer2::Core::Types which introduces a number of incompatibilities.

This particular D2 change was merged just before release and so I missed it when testing just a few days earlier. Apologies for yet another forced change.